### PR TITLE
Fix NullException when an item has no socket

### DIFF
--- a/PathOfExileNetWorth/GggData.cs
+++ b/PathOfExileNetWorth/GggData.cs
@@ -202,7 +202,7 @@ namespace PathOfExileNetWorth
         public ItemOnForm(Item i, Dictionary<string, float> priceOf)
         {
             Dictionary<int, int> dict = new Dictionary<int, int>();
-            foreach(Socket s in i.sockets)
+            foreach (Socket s in i.sockets ?? Enumerable.Empty<Socket>())
             {
                 if (dict.ContainsKey(s.group)) { dict[s.group]++; } else { dict.Add(s.group, 1); }
             }


### PR DESCRIPTION
Parsing items without sockets was not working properly for me without this check, resulting in a constant "0 chaos" display and no items found.